### PR TITLE
Updating the 'length_' parameter when using the operator +.

### DIFF
--- a/src/core/string.cxx
+++ b/src/core/string.cxx
@@ -187,7 +187,8 @@ namespace utf8
     string & string::operator += (string const & other)
     {
         unsigned oldsize = static_cast<unsigned>(data_.size());
-        data_.resize(data_.size() + other.data_.size());
+        length_ = data_.size() + other.data_.size();
+        data_.resize(length_);
         std::memcpy(&(data_[oldsize]), &(other.data_[0]), other.data_.size());
         return *this;
     }


### PR DESCRIPTION
Before it was like

```
utf8::string("as")   +   \\ length()  = 2
utf8::string("df")    =   \\ length()  = 2
utf8::string("asdf")     \\ length()  = 0
```

Whenever I joined two strings a new string with zero length was created.
This should resolve this problem.
